### PR TITLE
Enabling Sustainability Related Reports

### DIFF
--- a/src/Assessment/Parser/BusinessCaseParser.cs
+++ b/src/Assessment/Parser/BusinessCaseParser.cs
@@ -118,7 +118,9 @@ namespace Azure.Migrate.Export.Assessment.Parser
             BusinessCaseData.SqlServerLicense.ComputeLicenseCost = bizCaseOverviewSummariesJsonObj.Properties?.SqlAhubSavings ?? 0.00;
             BusinessCaseData.EsuSavings.ComputeLicenseCost = bizCaseOverviewSummariesJsonObj.Properties?.EsuSavingsFor4years ?? 0.00;
 
-            BusinessCaseData.TotalYOYCashFlows = bizCaseOverviewSummariesJsonObj.Properties.YearOnYearEstimates;
+            BusinessCaseData.TotalYOYCashFlowsAndEmissions = bizCaseOverviewSummariesJsonObj.Properties.YearOnYearEstimates;
+            BusinessCaseData.TotalAzureSustainabilityDetails = bizCaseOverviewSummariesJsonObj.Properties.TotalAzureSustainabilityDetails;
+            BusinessCaseData.TotalOnPremisesSustainabilityDetails = bizCaseOverviewSummariesJsonObj.Properties.TotalOnPremisesSustainabilityDetails;
             if (userInputObj.BusinessProposal == BusinessProposal.AVS.ToString())
                 BusinessCaseData.AvsYOYCashFlows = bizCaseAvsSummariesJsonObj.Properties.AzureAvsSummary.YearOnYearEstimates;
             else

--- a/src/Common/CoreReportConstants.cs
+++ b/src/Common/CoreReportConstants.cs
@@ -658,5 +658,25 @@ namespace Azure.Migrate.Export.Common
             "Machine Name",
             "Machine ID"
         };
+        public const string YOY_Emissions_TabName = "YOY_Emissions";
+        public static readonly List<string> YOY_Emissions_Columns = new List<string>
+        {
+            "Source",
+            "Year 0",
+            "Year 1",
+            "Year 2",
+            "Year 3"
+        };
+        public const string Emissions_Details_TabName = "Emissions_Details";
+        public static readonly List<string> Emissions_Details_Columns = new List<string>
+        {
+            "Source",
+            "Scope 1 Compute",
+            "Scope 1 Storage",
+            "Scope 2 Compute",
+            "Scope 2 Storage",
+            "Scope 3 Compute",
+            "Scope 3 Storage"
+        };
     }
 }

--- a/src/Common/Routes.cs
+++ b/src/Common/Routes.cs
@@ -41,7 +41,7 @@ namespace Azure.Migrate.Export.Common
         public const string ImportSitesApiVersion = @"2023-06-06";
         public const string AssessmentMachineListApiVersion = @"2023-03-03";
         public const string AvsAssessmentApiVersion = @"2023-05-01-preview";
-        public const string BusinessCaseApiVersion = @"2023-09-09-preview";
+        public const string BusinessCaseApiVersion = @"2024-03-03-preview";
         public const string QueryParameterApiVersion = @"api-version";
         public const string AzureMigrateQueryParameterFilter = @"filter";
         public const string AzureMigrateQueryPathProperties = @"Properties";

--- a/src/Excel/ExportCoreReport.cs
+++ b/src/Excel/ExportCoreReport.cs
@@ -28,6 +28,8 @@ namespace Azure.Migrate.Export.Excel
         private readonly List<AVS_Summary> AVS_Summary_List;
         private readonly List<AVS_IaaS_Rehost_Perf> AVS_IaaS_Rehost_Perf_List;
         private readonly List<Decommissioned_Machines> Decommissioned_Machines_List;
+        private readonly List<EmissionsDetails> EmissionsDetailsList;
+        private readonly List<YOY_Emissions> YOY_EmissionsList;
 
         XLWorkbook CoreWb;
 
@@ -52,7 +54,10 @@ namespace Azure.Migrate.Export.Excel
                 Cash_Flows cash_Flows_Data,
                 List<AVS_Summary> avs_Summary_List,
                 List<AVS_IaaS_Rehost_Perf> avs_IaaS_Rehost_Perf_List,
-                List<Decommissioned_Machines> decommissioned_Machines_List
+                List<Decommissioned_Machines> decommissioned_Machines_List,
+                List<EmissionsDetails> emissionsDetailsList,
+                List<YOY_Emissions> yoy_EmissionsList
+
             )
         {
             CorePropertiesObj = corePropertiesObj;
@@ -75,6 +80,8 @@ namespace Azure.Migrate.Export.Excel
             AVS_Summary_List = avs_Summary_List;
             AVS_IaaS_Rehost_Perf_List = avs_IaaS_Rehost_Perf_List;
             Decommissioned_Machines_List = decommissioned_Machines_List;
+            EmissionsDetailsList = emissionsDetailsList;
+            YOY_EmissionsList = yoy_EmissionsList;
 
             CoreWb = new XLWorkbook();
         }
@@ -101,7 +108,9 @@ namespace Azure.Migrate.Export.Excel
             Generate_AVS_Summary_Worksheet();
             Generate_AVS_IaaS_Server_Rehost_Perf_Worksheet();
             Generate_Decommissioned_Machines_Worksheet();
-            
+            Generate_YOY_Emissions_Worksheet();
+            Generate_Emissions_Details_Worksheet();
+
             CoreWb.SaveAs(CoreReportConstants.CoreReportPath);
         }
 
@@ -238,7 +247,7 @@ namespace Azure.Migrate.Export.Excel
 
             for (int i = 0; i < CoreReportConstants.Cash_Flows_Years.Count; i++)
                 dataWs.Cell(1, i + 3).Value = CoreReportConstants.Cash_Flows_Years[i];
-            
+
             for (int i = 0; i < CoreReportConstants.Cash_Flows_CloudComputingServiceTypes.Count; i++)
             {
                 dataWs.Cell(3 * i + 2, 1).Value = CoreReportConstants.Cash_Flows_CloudComputingServiceTypes[i];
@@ -460,7 +469,7 @@ namespace Azure.Migrate.Export.Excel
             if (SQL_All_Instances_List != null && SQL_All_Instances_List.Count > 0)
                 dataWs.Cell(2, 1).InsertData(SQL_All_Instances_List);
         }
-        
+
         private void Generate_All_VM_IaaS_Server_Rehost_Perf_Worksheet()
         {
             var dataWs = CoreWb.Worksheets.Add(CoreReportConstants.All_VM_IaaS_Server_Rehost_Perf_TabName, 15);
@@ -499,6 +508,22 @@ namespace Azure.Migrate.Export.Excel
 
             if (Decommissioned_Machines_List != null & Decommissioned_Machines_List.Count > 0)
                 dataWs.Cell(2, 1).InsertData(Decommissioned_Machines_List);
+        }
+
+        private void Generate_YOY_Emissions_Worksheet()
+        {
+            var dataWs = CoreWb.Worksheets.Add(CoreReportConstants.YOY_Emissions_TabName, 19);
+            UtilityFunctions.AddColumnHeadersToWorksheet(dataWs, CoreReportConstants.YOY_Emissions_Columns);
+            if (YOY_EmissionsList != null && YOY_EmissionsList.Count > 0)
+                dataWs.Cell(2, 1).InsertData(YOY_EmissionsList);
+        }
+
+        private void Generate_Emissions_Details_Worksheet()
+        {
+            var dataWs = CoreWb.Worksheets.Add(CoreReportConstants.Emissions_Details_TabName, 20);
+            UtilityFunctions.AddColumnHeadersToWorksheet(dataWs, CoreReportConstants.Emissions_Details_Columns);
+            if (EmissionsDetailsList != null && EmissionsDetailsList.Count > 0)
+                dataWs.Cell(2, 1).InsertData(EmissionsDetailsList);
         }
     }
 }

--- a/src/Models/Assessment/Datasets/BusinessCaseDataset.cs
+++ b/src/Models/Assessment/Datasets/BusinessCaseDataset.cs
@@ -13,9 +13,11 @@
             WindowsServerLicense = new BusinessCaseDatasetCostDetails();
             SqlServerLicense = new BusinessCaseDatasetCostDetails();
             EsuSavings = new BusinessCaseDatasetCostDetails();
-            TotalYOYCashFlows = new BusinessCaseYOYCostDetailsJSON();
+            TotalYOYCashFlowsAndEmissions = new BusinessCaseYOYJSON();
             IaaSYOYCashFlows = new BusinessCaseYOYCostDetailsJSON();
             AvsYOYCashFlows = new BusinessCaseYOYCostDetailsJSON();
+            TotalAzureSustainabilityDetails = new CarbonEmissionsDetails();
+            TotalOnPremisesSustainabilityDetails = new CarbonEmissionsDetails();
         }
 
         public BusinessCaseDatasetCostDetails OnPremIaaSCostDetails { get; set; } = null;
@@ -27,8 +29,10 @@
         public BusinessCaseDatasetCostDetails WindowsServerLicense { get; set; }
         public BusinessCaseDatasetCostDetails SqlServerLicense { get; set; }
         public BusinessCaseDatasetCostDetails EsuSavings { get; set; }
-        public BusinessCaseYOYCostDetailsJSON TotalYOYCashFlows { get; set; } = null;
+        public BusinessCaseYOYJSON TotalYOYCashFlowsAndEmissions { get; set; } = null;
         public BusinessCaseYOYCostDetailsJSON IaaSYOYCashFlows { get; set; } = null;
         public BusinessCaseYOYCostDetailsJSON AvsYOYCashFlows { get; set; } = null;
+        public CarbonEmissionsDetails TotalAzureSustainabilityDetails { get; set; } = null;
+        public CarbonEmissionsDetails TotalOnPremisesSustainabilityDetails { get; set; } = null;
     }
 }

--- a/src/Models/Assessment/Excel/CoreReport/EmissionsDetails.cs
+++ b/src/Models/Assessment/Excel/CoreReport/EmissionsDetails.cs
@@ -1,0 +1,13 @@
+﻿namespace Azure.Migrate.Export.Models
+{
+    public class EmissionsDetails
+    {
+        public string Source { get; set; }
+        public double Scope1Compute { get; set; }
+        public double Scope1Storage { get; set; }
+        public double Scope2Compute { get; set; }
+        public double Scope2Storage { get; set; }
+        public double Scope3Compute { get; set; }
+        public double Scope3Storage { get; set; }
+    }
+}

--- a/src/Models/Assessment/Excel/CoreReport/YOY_Emissions.cs
+++ b/src/Models/Assessment/Excel/CoreReport/YOY_Emissions.cs
@@ -1,0 +1,11 @@
+﻿namespace Azure.Migrate.Export.Models
+{
+    public class YOY_Emissions
+    {
+        public string Source { get; set; }
+        public double Year0 { get; set; }
+        public double Year1 { get; set; }
+        public double Year2 { get; set; }
+        public double Year3 { get; set; }
+    }
+}

--- a/src/Models/JSONResponses/Assessment/BusinessCaseOverviewSummaryJSON.cs
+++ b/src/Models/JSONResponses/Assessment/BusinessCaseOverviewSummaryJSON.cs
@@ -23,6 +23,12 @@ namespace Azure.Migrate.Export.Models
         public double EsuSavingsFor4years { get; set; }
 
         [JsonProperty("yearOnYearEstimates")]
-        public BusinessCaseYOYCostDetailsJSON YearOnYearEstimates { get; set; }
+        public BusinessCaseYOYJSON YearOnYearEstimates { get; set; }
+
+        [JsonProperty("totalAzureSustainabilityDetails")]
+        public CarbonEmissionsDetails TotalAzureSustainabilityDetails { get; set; }
+
+        [JsonProperty("totalOnPremisesSustainabilityDetails")]
+        public CarbonEmissionsDetails TotalOnPremisesSustainabilityDetails { get; set; }
     }
 }

--- a/src/Models/JSONResponses/Assessment/BusinessCaseYOYCostDetailsJSON.cs
+++ b/src/Models/JSONResponses/Assessment/BusinessCaseYOYCostDetailsJSON.cs
@@ -1,4 +1,7 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Azure.Migrate.Export.Models
 {
@@ -21,6 +24,34 @@ namespace Azure.Migrate.Export.Models
         public BusinessCaseYOYCostBreakdown SavingsYOY { get; set; }
     }
 
+    public class BusinessCaseYOYJSON
+    {
+        public BusinessCaseYOYJSON()
+        {
+            OnPremisesCostYOY = new BusinessCaseYOYCostBreakdown();
+            AzureCostYOY = new BusinessCaseYOYCostBreakdown();
+            SavingsYOY = new BusinessCaseYOYCostBreakdown();
+            AzureEmissionsEstimates = new List<YearOnYearEmission>();
+
+            OnPremisesEmissionsEstimates = new List<YearOnYearEmission>();
+        }
+
+        [JsonProperty("onPremisesCost")]
+        public BusinessCaseYOYCostBreakdown OnPremisesCostYOY { get; set; }
+
+        [JsonProperty("azureCost")]
+        public BusinessCaseYOYCostBreakdown AzureCostYOY { get; set; }
+
+        [JsonProperty("savings")]
+        public BusinessCaseYOYCostBreakdown SavingsYOY { get; set; }
+
+        [JsonProperty("azureEmissionsEstimates")]
+        public List<YearOnYearEmission> AzureEmissionsEstimates { get; set; }
+
+        [JsonProperty("onPremisesEmissionsEstimates")]
+        public List<YearOnYearEmission> OnPremisesEmissionsEstimates { get; set; }
+    }
+
     public class BusinessCaseYOYCostBreakdown
     {
         [JsonProperty("Year0")]
@@ -34,5 +65,30 @@ namespace Azure.Migrate.Export.Models
 
         [JsonProperty("Year3")]
         public double Year3 { get; set; }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum Year
+    {
+        [EnumMember(Value = "Year0")]
+        Year0,
+
+        [EnumMember(Value = "Year1")]
+        Year1,
+
+        [EnumMember(Value = "Year2")]
+        Year2,
+
+        [EnumMember(Value = "Year3")]
+        Year3
+    }
+
+    public class YearOnYearEmission
+    {
+        [JsonProperty("year")]
+        public string Year { get; set; }
+
+        [JsonProperty("emissions")]
+        public double? Emissions { get; set; }
     }
 }

--- a/src/Models/JSONResponses/Assessment/CarbonEmissionsDetails.cs
+++ b/src/Models/JSONResponses/Assessment/CarbonEmissionsDetails.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Migrate.Export.Models
+{
+    public class CarbonEmissionsDetails
+    {
+        [JsonProperty("scope1")]
+        public CarbonEmissionsScopeDetails Scope1 { get; set; }
+
+        [JsonProperty("scope2")]
+        public CarbonEmissionsScopeDetails Scope2 { get; set; }
+
+        [JsonProperty("scope3")]
+        public CarbonEmissionsScopeDetails Scope3 { get; set; }
+    }
+
+    public class CarbonEmissionsScopeDetails
+    {
+        [JsonProperty("compute")]
+        public double Compute { get; set; }
+
+        [JsonProperty("storage")]
+        public double Storage { get; set; }
+    }
+}


### PR DESCRIPTION
Added support for creating two new worksheets in the core report which will be used for powering the sustainability details in AME. The two new sheets are as follows:

1. Emissions_Details
2. YOY_Emissions

As a part of this PR we are also moving to a new API version for business case where sustainability details are available