### PR TITLE
Fix: Add UAE North region to missing binding in AssessmentSettings

### DIFF
--- a/src/AssessmentSettings.xaml.cs
+++ b/src/AssessmentSettings.xaml.cs
@@ -109,6 +109,7 @@ namespace AzureMigrateExplore
             new KeyValuePair<string, string>("southcentralus", "South Central US"),
             new KeyValuePair<string, string>("southeastasia", "Southeast Asia"),
             new KeyValuePair<string, string>("swedencentral", "Sweden Central"),
+            new KeyValuePair<string, string>("uaenorth", "UAE North"),
             new KeyValuePair<string, string>("uksouth", "UK South"),
             new KeyValuePair<string, string>("ukwest", "UK West"),
             new KeyValuePair<string, string>("westeurope", "West Europe"),


### PR DESCRIPTION
This update ensures the UAE North region is properly listed in the Assessment screen during region selection.

Although UAE North was already present in AssessmentSettings.xaml.cs, an additional binding location was missing, which caused it not to render in the UI. This fix updates the required binding to ensure full visibility.

✅ Changes Made

Verified UAE North region entry exists

Updated necessary UI binding logic to reflect the region correctly in the assessment dropdown

📌 Notes

Tested and confirmed visibility of UAE North in the running app UI.